### PR TITLE
update alpine base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE: needs to match base/yarn.sh
-FROM node:8.16.2-alpine
+FROM node:8.13.0-alpine
 
 ARG container_user_id
 ARG s_base_name

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE: needs to match base/yarn.sh
-FROM node:8.11.3-alpine
+FROM node:8.16.2-alpine
 
 ARG container_user_id
 ARG s_base_name

--- a/base/package.json
+++ b/base/package.json
@@ -24,7 +24,7 @@
     ]
   },
   "devDependencies": {
-    "@types/express": "^4.16.1",
+    "@types/express": "^4.17.2",
     "@types/jest": "^24.0.11",
     "@types/superstruct": "^0.5.0",
     "@typescript-eslint/eslint-plugin": "^1.6.0",
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "body-parser": "^1.19.0",
-    "express": "^4.16.4",
+    "express": "^4.17.1",
     "jest-express": "^1.10.0",
     "superstruct": "^0.6.1"
   }

--- a/base/yarn.sh
+++ b/base/yarn.sh
@@ -17,4 +17,4 @@ docker run \
   --volume $RUN_DIR:/app \
   --workdir /app \
   --entrypoint yarn \
-  node:8.16.2-alpine ${@:1}
+  node:8.13.0-alpine ${@:1}

--- a/base/yarn.sh
+++ b/base/yarn.sh
@@ -17,4 +17,4 @@ docker run \
   --volume $RUN_DIR:/app \
   --workdir /app \
   --entrypoint yarn \
-  node:8.11.3-alpine ${@:1}
+  node:8.16.2-alpine ${@:1}

--- a/templates/now.staging.json
+++ b/templates/now.staging.json
@@ -2,13 +2,15 @@
   "name": "now-node-ts",
   "alias": ["now-node-ts.now.sh"],
   "version": 2,
+  "env": {
+    "EXAMPLE": "@example-value"
+  },
   "builds": [
-    { "src": "./dist/**/*.js", "use": "@now/node" }
+    { "src": "./src-to-deploy/**/*.route.ts", "use": "@now/node" }
   ],
   "routes": [
-    { "src": "/", "dest": "/dist/index.js" },
-    { "src": "/(.*)", "dest": "/dist/$1" }
+    { "src": "/", "dest": "/src-to-deploy/lib/index.route.ts" },
+    { "src": "/(.+)", "dest": "/src-to-deploy/lib/$1.route.ts" }
   ],
-  "regions": ["bru"]
+  "regions": ["all"]
 }
-

--- a/templates/s_node_2nd.sh
+++ b/templates/s_node_2nd.sh
@@ -4,6 +4,14 @@ cd $SCRIPT_DIR
 
 NAME=s_node_2nd
 VERSION=v1
+IMAGE=saavu-local/${NAME}_${VERSION}
+
+if [ "$(docker images -q $IMAGE 2> /dev/null)" = "" ] && [ ! -f .reset-initiated ]; then
+  echo "Image missing, reset."
+  touch .reset-initiated
+  rm -f .ejected
+  rm -rf s_base/${NAME}
+fi
 
 if [ ! -d ./s_base/${NAME} ]; then
   mkdir -p s_base/${NAME}
@@ -15,7 +23,7 @@ fi
 # following line to automatically trigger updates to a specific target SHA for
 # all users if the base has been updated. Use the 7 digit short format for the
 # git SHA.
-GIT_SHA_SHOULD_BE="LATEST"
+GIT_SHA_SHOULD_BE="9eda5e4"
 GIT_SHA_IS=$(cd s_base/$NAME && git log --pretty=format:'%h' -n 1)
 
 if [ "$GIT_SHA_SHOULD_BE" != "LATEST" ]; then
@@ -24,6 +32,7 @@ if [ "$GIT_SHA_SHOULD_BE" != "LATEST" ]; then
     echo "..."
     sleep 3
     ./s_base/${NAME}/init.sh $GIT_SHA_SHOULD_BE
+    rm -f .reset-initiated
   fi
 fi
 

--- a/templates/s_node_2nd.sh
+++ b/templates/s_node_2nd.sh
@@ -23,7 +23,7 @@ fi
 # following line to automatically trigger updates to a specific target SHA for
 # all users if the base has been updated. Use the 7 digit short format for the
 # git SHA.
-GIT_SHA_SHOULD_BE="9eda5e4"
+GIT_SHA_SHOULD_BE="LATEST"
 GIT_SHA_IS=$(cd s_base/$NAME && git log --pretty=format:'%h' -n 1)
 
 if [ "$GIT_SHA_SHOULD_BE" != "LATEST" ]; then


### PR DESCRIPTION
`firebase-admin` required node version 8.13.0 || >=10.10.0 to be compatible with our `watch` commands (jest/lint). I took a look at docker hub and seems 8.16.2 is the latest for node v8.

**EDIT**
Switched to node:8.13.0-alpine, using 8.16.2 breaks jest globals and I was unsure how to fix (quickly).

I think I'll be learning more about this setup when working on the updating typescript issue.