### PR TITLE
bump express version and types

### DIFF
--- a/base/package.json
+++ b/base/package.json
@@ -24,7 +24,7 @@
     ]
   },
   "devDependencies": {
-    "@types/express": "^4.16.1",
+    "@types/express": "^4.17.2",
     "@types/jest": "^24.0.11",
     "@types/superstruct": "^0.5.0",
     "@typescript-eslint/eslint-plugin": "^1.6.0",
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "body-parser": "^1.19.0",
-    "express": "^4.16.4",
+    "express": "^4.17.1",
     "jest-express": "^1.10.0",
     "superstruct": "^0.6.1"
   }


### PR DESCRIPTION
This fixes an issue with express that I think was caused with the update to our node image. The express error is below.

```
TypeError: Cannot read property 'lookup' of undefined
    at ServerResponse.header (/s_node_2nd/node_modules/express/lib/response.js:762:37)
    at ServerResponse.json (/s_node_2nd/node_modules/express/lib/response.js:264:10)
    at default_1 (/s_node_2nd/src/lib/helpers/auth.ts:32:28)
    at Layer.handle [as handle_request] (/s_node_2nd/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/s_node_2nd/node_modules/express/lib/router/index.js:317:13)
    at /s_node_2nd/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/s_node_2nd/node_modules/express/lib/router/index.js:335:12)
    at next (/s_node_2nd/node_modules/express/lib/router/index.js:275:10)
    at cors (/s_node_2nd/node_modules/cors/lib/index.js:188:7)
    at /s_node_2nd/node_modules/cors/lib/index.js:224:17
```
